### PR TITLE
Fix compilation bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,12 @@ add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-w>)
 if (DEBUG)
   add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-g>)
 endif()
+if (LARGEN)
+  # LARGEN's enlarged COMMON blocks (e.g. MAXBUF) overflow the default
+  # small memory model's 32-bit relocations, so linking needs a wider model.
+  add_compile_options($<$<COMPILE_LANGUAGE:C>:-mcmodel=medium>)
+  add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-mcmodel=medium>)
+endif()
 
 # Dependencies
 find_package(X11 REQUIRED)

--- a/pgplot/CMakeLists.txt
+++ b/pgplot/CMakeLists.txt
@@ -10,6 +10,14 @@ else()
   set(PGPLOT_PLATFORM linux)
 endif()
 
+set(PGPLOT_EXTRA_ARGS "")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+  # DOWNLOAD_EXTRACT_TIMESTAMP is only recognized by ExternalProject_Add on
+  # CMake >= 3.24; on older versions it gets silently swallowed into the
+  # preceding PATCH_COMMAND argument list, corrupting the patch invocation.
+  list(APPEND PGPLOT_EXTRA_ARGS DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+endif()
+
 ExternalProject_Add(pgplot_ext
   URL https://sites.astro.caltech.edu/~tjp/pgplot/macos/pgplot531.tar.gz
   URL_HASH SHA256=4bcb09a03b19ebfe30e79435a54e641478099e674f4df8a289fdbde3a827f7bf
@@ -22,7 +30,7 @@ ExternalProject_Add(pgplot_ext
   INSTALL_COMMAND ""
   BUILD_IN_SOURCE 1
   PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/patches/pgplot531.patch
-  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+  ${PGPLOT_EXTRA_ARGS}
 )
 
 # Define an imported library target for the built PGPLOT static library


### PR DESCRIPTION
Hi there,

I hit a couple of compilation/build bugs with `-DLARGEN=ON` and `CMake` < 3.24 - this should fix both:

- pgplot/CMakeLists.txt: DOWNLOAD_EXTRACT_TIMESTAMP is only a recognized
  ExternalProject_Add keyword on CMake >= 3.24. On older CMake it was
  getting absorbed into PATCH_COMMAND, corrupting the patch invocation
  (`patch: Can't open patch file TRUE`). Now only passed when supported.

- CMakeLists.txt: LARGEN's enlarged COMMON blocks overflow the default
  small memory model's 32-bit relocations at link time
  (`relocation truncated to fit`). Add -mcmodel=medium for C/Fortran
  when LARGEN is enabled.
